### PR TITLE
Add make new Nii image functionality and bug fixes

### DIFF
--- a/annotation.go
+++ b/annotation.go
@@ -5,9 +5,10 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"os"
+
 	"github.com/okieraised/gonii/internal/system"
 	"github.com/okieraised/gonii/pkg/nifti"
-	"os"
 )
 
 type Segmentation struct {

--- a/annotation_test.go
+++ b/annotation_test.go
@@ -3,11 +3,12 @@ package gonii
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/okieraised/gonii/pkg/nifti"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/okieraised/gonii/pkg/nifti"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewSegmentation_Json_1(t *testing.T) {

--- a/io.go
+++ b/io.go
@@ -3,10 +3,11 @@ package gonii
 import (
 	"bytes"
 	"encoding/binary"
-	"github.com/okieraised/gonii/internal/utils"
-	"github.com/okieraised/gonii/pkg/nifti"
 	"net/http"
 	"os"
+
+	"github.com/okieraised/gonii/internal/utils"
+	"github.com/okieraised/gonii/pkg/nifti"
 )
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/io_benchmark_test.go
+++ b/io_benchmark_test.go
@@ -1,9 +1,10 @@
 package gonii
 
 import (
+	"testing"
+
 	"github.com/okieraised/gonii/internal/utils"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func Test_ReaderProfiling_90MBCompressed(t *testing.T) {

--- a/io_test.go
+++ b/io_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"os"
+	"testing"
+
 	"github.com/okieraised/gonii/pkg/matrix"
 	"github.com/okieraised/gonii/pkg/nifti"
 	"github.com/stretchr/testify/assert"
-	"os"
-	"testing"
 )
 
 func TestNewNiiReader_1(t *testing.T) {

--- a/pkg/nifti/annotation_rle.go
+++ b/pkg/nifti/annotation_rle.go
@@ -59,8 +59,7 @@ func (a *SegmentRLE) Decode() {
 	var deflatedSegment []float64
 
 	for idx, segmentLength := range a.EncodedSeg {
-		var s []float64
-		s = make([]float64, int(segmentLength))
+		s := make([]float64, int(segmentLength))
 		if idx%2 == 0 {
 			for i := range s {
 				s[i] = 0

--- a/pkg/nifti/calculation.go
+++ b/pkg/nifti/calculation.go
@@ -1,8 +1,9 @@
 package nifti
 
 import (
-	"github.com/okieraised/gonii/pkg/matrix"
 	"math"
+
+	"github.com/okieraised/gonii/pkg/matrix"
 )
 
 // QuaternToMatrix returns the transformation matrix from the quaternion parameters

--- a/pkg/nifti/helper.go
+++ b/pkg/nifti/helper.go
@@ -537,7 +537,7 @@ func MakeEmptyImageFromImg(img *Nii) ([]byte, error) {
 	bDataLength = bDataLength * int64(nByper)
 
 	// Init a slice of bytes with capacity of bDataLength and initial value of 0
-	bData := make([]byte, bDataLength, bDataLength)
+	bData := make([]byte, bDataLength)
 
 	return bData, nil
 }
@@ -578,7 +578,7 @@ func MakeEmptyImageFromHdr(hdr *Nii1Header) ([]byte, error) {
 	bDataLength = bDataLength * int64(nByper)
 
 	// Init a slice of bytes with capacity of bDataLength and initial value of 0
-	bData := make([]byte, bDataLength, bDataLength)
+	bData := make([]byte, bDataLength)
 
 	return bData, nil
 }

--- a/pkg/nifti/helper.go
+++ b/pkg/nifti/helper.go
@@ -6,10 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	gzip "github.com/klauspost/pgzip"
-	"github.com/okieraised/gonii/internal/system"
 	"math"
 	"os"
+
+	gzip "github.com/klauspost/pgzip"
+	"github.com/okieraised/gonii/internal/system"
 )
 
 // IsValidDatatype checks whether the datatype is valid for NIFTI format

--- a/pkg/nifti/helper.go
+++ b/pkg/nifti/helper.go
@@ -556,7 +556,7 @@ func MakeEmptyImageFromHdr(hdr *Nii1Header) ([]byte, error) {
 	if hdr.Dim[2] == 0 {
 		return nil, errors.New("y dimension must not be zero")
 	}
-	bDataLength = int64(hdr.Dim[1] * hdr.Dim[2])
+	bDataLength = int64(hdr.Dim[1]) * int64(hdr.Dim[2])
 
 	if hdr.Dim[3] > 0 {
 		bDataLength = bDataLength * int64(hdr.Dim[3])

--- a/pkg/nifti/helper.go
+++ b/pkg/nifti/helper.go
@@ -500,6 +500,66 @@ func MakeNewNii2Header(inDim *[8]int64, inDatatype int32) *Nii2Header {
 	return header
 }
 
+func MakeNewNiiImageFromHdr(hdr interface{}) (*Nii, error) {
+	var img Nii
+	switch h := hdr.(type) {
+	case *Nii1Header:
+		img.PixDim = [8]float64{
+			float64(h.Pixdim[0]),
+			float64(h.Pixdim[1]),
+			float64(h.Pixdim[2]),
+			float64(h.Pixdim[3]),
+			float64(h.Pixdim[4]),
+			float64(h.Pixdim[5]),
+			float64(h.Pixdim[6]),
+			float64(h.Pixdim[7]),
+		}
+		img.Dim = [8]int64{
+			int64(h.Dim[0]),
+			int64(h.Dim[1]),
+			int64(h.Dim[2]),
+			int64(h.Dim[3]),
+			int64(h.Dim[4]),
+			int64(h.Dim[5]),
+			int64(h.Dim[6]),
+			int64(h.Dim[7]),
+		}
+		img.NDim = int64(h.Dim[0])
+		img.Nx = int64(h.Dim[1])
+		img.Ny = int64(h.Dim[2])
+		img.Nz = int64(h.Dim[3])
+		img.Nt = int64(h.Dim[4])
+		img.Nu = int64(h.Dim[5])
+		img.Nv = int64(h.Dim[6])
+		img.Nw = int64(h.Dim[7])
+		img.Datatype = int32(h.Datatype)
+		img.ByteOrder = binary.LittleEndian
+		img.SclSlope = float64(h.SclSlope)
+		img.SclInter = float64(h.SclInter)
+		img.VoxOffset = float64(h.VoxOffset)
+	case *Nii2Header:
+		img.PixDim = h.Pixdim
+		img.Dim = h.Dim
+		img.NDim = h.Dim[0]
+		img.Nx = h.Dim[1]
+		img.Ny = h.Dim[2]
+		img.Nz = h.Dim[3]
+		img.Nt = h.Dim[4]
+		img.Nu = h.Dim[5]
+		img.Nv = h.Dim[6]
+		img.Nw = h.Dim[7]
+		img.Datatype = int32(h.Datatype)
+		img.ByteOrder = binary.LittleEndian
+		img.SclSlope = h.SclSlope
+		img.SclInter = h.SclInter
+		img.VoxOffset = float64(h.VoxOffset)
+	default:
+		return nil, fmt.Errorf("unknown header type")
+	}
+
+	return &img, nil
+}
+
 // MakeEmptyImageFromImg returns a zero-filled byte slice from existing Nii image structure
 func MakeEmptyImageFromImg(img *Nii) ([]byte, error) {
 	var bDataLength int64

--- a/pkg/nifti/nifti.go
+++ b/pkg/nifti/nifti.go
@@ -775,7 +775,7 @@ func (n *Nii) SetAt(newVal float64, x, y, z, t int64) error {
 
 // SetVoxelToRawVolume converts the 1-D slice of float64 back to byte array
 func (n *Nii) SetVoxelToRawVolume(vox *Voxels) error {
-	result := make([]byte, vox.GetRawByteSize(), vox.GetRawByteSize())
+	result := make([]byte, vox.GetRawByteSize())
 	nByPer := n.NByPer
 
 	for index, voxel := range vox.voxel {

--- a/pkg/nifti/nifti.go
+++ b/pkg/nifti/nifti.go
@@ -388,7 +388,7 @@ func (n *Nii) GetAffine() matrix.DMat44 {
 func (n *Nii) GetImgShape() [4]int64 {
 	dim := [4]int64{}
 
-	for index, _ := range dim {
+	for index := range dim {
 		dim[index] = n.Dim[index+1]
 	}
 	return dim
@@ -397,7 +397,7 @@ func (n *Nii) GetImgShape() [4]int64 {
 // GetVoxelSize returns the voxel size of the image
 func (n *Nii) GetVoxelSize() [4]float64 {
 	size := [4]float64{}
-	for index, _ := range size {
+	for index := range size {
 		size[index] = n.PixDim[index+1]
 	}
 	return size

--- a/pkg/nifti/nifti.go
+++ b/pkg/nifti/nifti.go
@@ -4,9 +4,10 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/okieraised/gonii/pkg/matrix"
 	"math"
 	"strings"
+
+	"github.com/okieraised/gonii/pkg/matrix"
 )
 
 // Nii defines the structure of the NIFTI-1 data for I/O purpose
@@ -652,8 +653,8 @@ func (n *Nii) SetSclInter(sclInter float64) {
 }
 
 // SetPixDim sets the PixDim parameter
-func (n *Nii) SetPixDim() [8]float64 {
-	return n.PixDim
+func (n *Nii) SetPixDim(pixDim [8]float64) {
+	n.PixDim = pixDim
 }
 
 // SetDim sets the Dim parameter

--- a/pkg/nifti/reader.go
+++ b/pkg/nifti/reader.go
@@ -5,8 +5,9 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/okieraised/gonii/pkg/matrix"
 	"io"
+
+	"github.com/okieraised/gonii/pkg/matrix"
 )
 
 type Reader interface {

--- a/pkg/nifti/voxel.go
+++ b/pkg/nifti/voxel.go
@@ -219,7 +219,7 @@ func (v *Voxels) ImportAsRLE() ([]SegmentRLE, error) {
 	for z := int64(0); z < v.dimZ; z++ {
 		for t := int64(0); t < v.dimT; t++ {
 			sliceData := v.GetSlice(z, t)
-			for key, _ := range valMapper {
+			for key := range valMapper {
 				if key == 0 {
 					continue
 				}

--- a/pkg/nifti/voxel.go
+++ b/pkg/nifti/voxel.go
@@ -2,6 +2,7 @@ package nifti
 
 import (
 	"errors"
+
 	"github.com/okieraised/gonii/internal/utils"
 )
 

--- a/pkg/nifti/writer.go
+++ b/pkg/nifti/writer.go
@@ -135,9 +135,9 @@ func (w *NiiWriter) reconstructDataset() ([]byte, error) {
 	}
 
 	if offsetFromHeaderToVoxel > 0 {
-		offset = make([]byte, offsetFromHeaderToVoxel, offsetFromHeaderToVoxel)
+		offset = make([]byte, offsetFromHeaderToVoxel)
 	} else {
-		offset = make([]byte, DefaultHeaderPadding, DefaultHeaderPadding)
+		offset = make([]byte, DefaultHeaderPadding)
 	}
 
 	// Make a buffer and write the header to it with default system endian
@@ -172,7 +172,6 @@ func (w *NiiWriter) writePairNii() error {
 		w.filePath = w.filePath + NIFTI_EXT
 	}
 
-	headerFilePath = w.filePath
 	// Now replace the suffix to identify the header and img file
 	headerFilePath = strings.ReplaceAll(w.filePath, NIFTI_EXT, "_nifti.hdr")
 	w.filePath = strings.ReplaceAll(w.filePath, NIFTI_EXT, "_nifti.img")
@@ -220,6 +219,9 @@ func (w *NiiWriter) writePairNii() error {
 			return err
 		}
 		err = gzipWriter.Close()
+		if err != nil {
+			return err
+		}
 
 		// Write compressed data to file
 		gzipWriter = gzip.NewWriter(fData)
@@ -228,6 +230,9 @@ func (w *NiiWriter) writePairNii() error {
 			return err
 		}
 		err = gzipWriter.Close()
+		if err != nil {
+			return err
+		}
 
 	} else { // Write both the header and image data normally
 		_, err = fHeader.Write(bHeader)

--- a/pkg/nifti/writer.go
+++ b/pkg/nifti/writer.go
@@ -5,11 +5,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	gzip "github.com/klauspost/pgzip"
-	"github.com/okieraised/gonii/internal/system"
 	"math"
 	"os"
 	"strings"
+
+	gzip "github.com/klauspost/pgzip"
+	"github.com/okieraised/gonii/internal/system"
 )
 
 type Writer interface {


### PR DESCRIPTION
This pull request includes various improvements and refactorings across multiple files to enhance code readability and maintainability. The most important changes include reordering import statements, simplifying slice initialization, and adding error handling for gzipWriter closure.


### New Functionality:
* Added a new function `MakeNewNiiImageFromHdr` in `pkg/nifti/helper.go` to create a new Nii image from a header.

### Import Reordering:
* Reordered imports for better organization in `annotation.go`, `annotation_test.go`, `io.go`, `io_benchmark_test.go`, `io_test.go`, `pkg/nifti/calculation.go`, `pkg/nifti/helper.go`, `pkg/nifti/nifti.go`, `pkg/nifti/reader.go`, `pkg/nifti/voxel.go`, and `pkg/nifti/writer.go`. [[1]](diffhunk://#diff-1a89f343eacb78796bcfb22fd393273f1c2d86a3e23db42ed6900bc4ba8a3f32R8-L10) [[2]](diffhunk://#diff-2419d277d1855cdd5eea0df6c735025523d86a88eb273be476af362f75aba7d3L6-R11) [[3]](diffhunk://#diff-2538bb8c5daf4057de32a936a59f125087b9bb7d0b2832b33e9743456e2a1ea3L6-R10) [[4]](diffhunk://#diff-5f5d72751bb3afd6a9326d3a119f26f1059a9e0c1e853a85e205d5093bc2f18aR4-L6) [[5]](diffhunk://#diff-990a89b9ef8023ed39ba1ec12f39ef0dc6e2c5b247c3237e537a90a559ed8db9R7-L11) [[6]](diffhunk://#diff-d4f8c94d5f5730219aa4fc5d5bcd57eb45929f3aa0e10a98c5eeed52fe8b4dcfL4-R6) [[7]](diffhunk://#diff-eba1fd4851de6e592156c2c1366c4dfc316b045f6527d29811795a0acaf1a1ffL9-R13) [[8]](diffhunk://#diff-82dc7237e1c8ec63d3b02b8bdb7506df03fa7a10d45cf335c2937600ad9a83feL7-R10) [[9]](diffhunk://#diff-2b13f837b0bfb2270f915abae471086736a451b9de9ae74dbdf85b49ac3bbd66L8-R10) [[10]](diffhunk://#diff-e5865b395a57428a3f9494da5f2a3760c2cd9296613a6de8c393b48639ad9771R5) [[11]](diffhunk://#diff-e5f5e3ae4b759c7385fc7faa8f3b5048062b4338ec15524686420a1f38251518L8-R13)

### Code Simplification:
* Simplified slice initialization in `pkg/nifti/annotation_rle.go`, `pkg/nifti/helper.go`, `pkg/nifti/nifti.go`, and `pkg/nifti/writer.go`. [[1]](diffhunk://#diff-f900439ea7ff9fff328b029079e5dd72993d18199da9dc8fd017bdf08ac437dfL62-R62) [[2]](diffhunk://#diff-eba1fd4851de6e592156c2c1366c4dfc316b045f6527d29811795a0acaf1a1ffL539-R600) [[3]](diffhunk://#diff-eba1fd4851de6e592156c2c1366c4dfc316b045f6527d29811795a0acaf1a1ffL558-R619) [[4]](diffhunk://#diff-82dc7237e1c8ec63d3b02b8bdb7506df03fa7a10d45cf335c2937600ad9a83feL777-R778) [[5]](diffhunk://#diff-e5f5e3ae4b759c7385fc7faa8f3b5048062b4338ec15524686420a1f38251518L137-R140)

### Error Handling:
* Added error handling for gzipWriter closure in `pkg/nifti/writer.go`. [[1]](diffhunk://#diff-e5f5e3ae4b759c7385fc7faa8f3b5048062b4338ec15524686420a1f38251518R222-R224) [[2]](diffhunk://#diff-e5f5e3ae4b759c7385fc7faa8f3b5048062b4338ec15524686420a1f38251518R233-R235)

### Minor Refactorings:
* Removed unnecessary variable declaration in `pkg/nifti/nifti.go` and `pkg/nifti/voxel.go`. [[1]](diffhunk://#diff-82dc7237e1c8ec63d3b02b8bdb7506df03fa7a10d45cf335c2937600ad9a83feL390-R391) [[2]](diffhunk://#diff-82dc7237e1c8ec63d3b02b8bdb7506df03fa7a10d45cf335c2937600ad9a83feL399-R400) [[3]](diffhunk://#diff-e5865b395a57428a3f9494da5f2a3760c2cd9296613a6de8c393b48639ad9771L221-R222)
* Corrected the multiplication logic in `pkg/nifti/helper.go`.